### PR TITLE
Allow the override of sss_allowed_groups.

### DIFF
--- a/site/roles/trinity/sssd/tasks/main.yml
+++ b/site/roles/trinity/sssd/tasks/main.yml
@@ -45,10 +45,12 @@
   shell: 'obol group list | grep {{ item }} || obol group add {{ item }}'
   register: obol_result
   with_items: '{{ sss_allowed_groups }}'
-  changed_when: item not in obol_result.stdout
+  changed_when: item not in obol_result.stdout and sss_allowed_groups not iterable
   when: primary|default(True)
         and ansible_connection not in 'lchroot'
         and not compute|default(False)
+        and sss_allowed_groups is defined
+        and sss_allowed_groups is iterable
 
 - name: Setting up the system to use sssd for authentication
   command: authconfig --enablemkhomedir --enablesssd --enablesssdauth --update

--- a/site/roles/trinity/sssd/templates/sssd.conf
+++ b/site/roles/trinity/sssd/templates/sssd.conf
@@ -32,7 +32,11 @@ ldap_search_base = dc=local
 ldap_network_timeout = 30
 
 ldap_access_order = {% if sss_filter_enabled %}filter,{% endif %}expire
+{% if sss_allowed_groups is iterable %}
 ldap_access_filter = {% for group in sss_allowed_groups %} (memberOf=cn={{ group }},ou=group,dc=local) {% endfor %}
+{% else %}
+ldap_access_filter = (&(objectclass=inetOrgPerson))
+{% endif %}
 
 
 ldap_account_expire_policy = shadow


### PR DESCRIPTION
If no group has been defined, it will allow all users from the class
inetOrgPerson. If there are definitions, it will add them to the LDAP
filter.
Usage for groups:
sss_allowed_groups:
  - admins
  - usergroup

This allows any user to login:
sss_allowed_groups: